### PR TITLE
fix: user text being interpreted as a format string

### DIFF
--- a/roff.go
+++ b/roff.go
@@ -44,14 +44,19 @@ func NewDocument() *Document {
 // write writes the given text to the internal buffer. Following the roff docs,
 // we prevent empty lines in its output, as that may mysteriously break some
 // roff renderers.
-func (tr *Document) writef(format string, args ...interface{}) {
+func (tr *Document) write(text string) {
 	if bytes.HasSuffix(tr.buffer.Bytes(), []byte("\n")) &&
-		strings.HasPrefix(format, "\n") {
+		strings.HasPrefix(text, "\n") {
 		// prevent empty lines in output
-		format = strings.TrimPrefix(format, "\n")
+		text = strings.TrimPrefix(text, "\n")
 	}
 
-	fmt.Fprintf(&tr.buffer, format, args...)
+	tr.buffer.WriteString(text)
+}
+
+// writef formats the given string and writes it to the internal buffer.
+func (tr *Document) writef(format string, args ...interface{}) {
+	tr.write(fmt.Sprintf(format, args...))
 }
 
 func (tr *Document) writelnf(format string, args ...interface{}) {
@@ -132,7 +137,7 @@ func (tr *Document) Text(text string) {
 				inList = false
 			}
 
-			tr.writef(escapeText(s))
+			tr.write(escapeText(s))
 		}
 	}
 }

--- a/roff_test.go
+++ b/roff_test.go
@@ -35,6 +35,31 @@ func TestText(t *testing.T) {
 	}
 }
 
+func TestTextVerbatim(t *testing.T) {
+	// User text must be written verbatim and must never be interpreted as a
+	// fmt format string (no verb expansion, no %!x(MISSING) artifacts).
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"percent literal", "100% complete", "100% complete"},
+		{"format verbs", "use %s and %d here", "use %s and %d here"},
+		{"percent verb alone", "%v", "%v"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := NewDocument()
+			doc.Text(tt.in)
+
+			if got := doc.String(); got != tt.want {
+				t.Errorf("Text(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTextBold(t *testing.T) {
 	doc := NewDocument()
 	doc.TextBold("Test")


### PR DESCRIPTION
Document.Text passed escaped user text as the format argument to fmt.Fprintf via writef, so any '%' in the text got expanded.