### PR TITLE
Escape roff special characters in macro arguments

### DIFF
--- a/roff.go
+++ b/roff.go
@@ -65,7 +65,7 @@ func (tr *Document) writelnf(format string, args ...interface{}) {
 
 // Heading writes the title heading of the document.
 func (tr *Document) Heading(section uint, title, description string, ts time.Time) {
-	tr.writef(TitleHeading, strings.ToUpper(title), section, title, ts.Format("2006-01-02"), description)
+	tr.writef(TitleHeading, escapeMacro(strings.ToUpper(title)), section, escapeMacro(title), ts.Format("2006-01-02"), escapeMacro(description))
 }
 
 // Paragraph starts a new paragraph.
@@ -103,7 +103,7 @@ func (tr *Document) List(text string) {
 
 // Section writes a section heading.
 func (tr *Document) Section(text string) {
-	tr.writelnf(SectionHeading, strings.ToUpper(text))
+	tr.writelnf(SectionHeading, escapeMacro(strings.ToUpper(text)))
 }
 
 // EndSection ends the current section.
@@ -164,5 +164,14 @@ func (tr Document) String() string {
 func escapeText(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\e`)
 	s = strings.ReplaceAll(s, ".", "\\&.")
+	return s
+}
+
+// escapeMacro escapes roff special characters in macro arguments so they are
+// rendered literally: backslashes would otherwise introduce escape sequences,
+// and double quotes would otherwise terminate quoted macro arguments.
+func escapeMacro(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\e`)
+	s = strings.ReplaceAll(s, `"`, `\(dq`)
 	return s
 }

--- a/roff_test.go
+++ b/roff_test.go
@@ -17,12 +17,36 @@ func TestTitleHeading(t *testing.T) {
 	}
 }
 
+func TestTitleHeadingEscaped(t *testing.T) {
+	// Backslashes and double quotes in macro arguments must be escaped so
+	// they are rendered literally instead of being interpreted by roff.
+	now := time.Now()
+	ts := now.Format("2006-01-02")
+
+	doc := NewDocument()
+	doc.Heading(1, `Ti"tle`, `A \"quoted" \path`, now)
+
+	want := `.TH TI\(dqTLE 1 "` + ts + `" "Ti\(dqtle" "A \e\(dqquoted\(dq \epath"`
+	if doc.String() != want {
+		t.Errorf("Expected escaped title heading, got: %q", doc.String())
+	}
+}
+
 func TestSectionHeading(t *testing.T) {
 	doc := NewDocument()
 	doc.Section("Test")
 
 	if doc.String() != "\n.SH TEST\n" {
 		t.Error("Expected section heading, got:", []byte(doc.String()))
+	}
+}
+
+func TestSectionHeadingEscaped(t *testing.T) {
+	doc := NewDocument()
+	doc.Section(`See "notes" \ here`)
+
+	if doc.String() != "\n.SH SEE \\(dqNOTES\\(dq \\e HERE\n" {
+		t.Error("Expected escaped section heading, got:", doc.String())
 	}
 }
 


### PR DESCRIPTION
Heading and Section wrote user-supplied text into .TH/.SH macro arguments without escaping, so a backslash introduced arbitrary roff escape sequences and a double quote terminated quoted .TH arguments early. Add escapeMacro, which renders backslashes and double quotes literally, and apply it to all user-supplied macro arguments.